### PR TITLE
Pseudoimage density segmentation

### DIFF
--- a/docs/computational/preprocessing_imaging.md
+++ b/docs/computational/preprocessing_imaging.md
@@ -40,6 +40,11 @@ a writeable folder).
      If you don't know how to specify the `<path_to_fiji_or_imagej>`, please follow the official instructions provided
      for [Running Headless](https://imagej.net/learn/headless)
 
+If each file in the folder is a z-stack, you don't need to specify anything else. Otherwise, if each file represents a 
+FOV and a Z plane (e.g., file names like Image_00001_Z001.tif, Image_00001_Z002.tif,...), you can specify a regex to
+parse the Z plane from the file names, and a single file per FOV will be created before stitching. This can be specified
+with the argument `--join-zstack-regex`, which by default is set to an empty string (i.e., no merging of Z planes is performed).
+
 ## (Optional) Addressing image irregularities
 Most of the times, large images have uneven illumination, focus or noise. This can be challenging when doing downstream
 processing on these images, like segmentation, feature extraction or quantification (i.e., on fluorescence images). 

--- a/docs/computational/preprocessing_imaging.md
+++ b/docs/computational/preprocessing_imaging.md
@@ -23,7 +23,7 @@ Open a terminal, and run the following command:
 openst image_stitch \
      --microscope='keyence' \
      --imagej-bin=<path_to_fiji_or_imagej> \
-     --tiles-dir=<path_to_tiles> \
+     --input-dir=<path_to_tiles> \
      --tiles-prefix=<to_read> \
      --tmp-dir=<tmp_dir> \
      --output-image=<output_image>

--- a/openst/alignment/manual_pairwise_aligner_gui.py
+++ b/openst/alignment/manual_pairwise_aligner_gui.py
@@ -45,7 +45,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtGui import QBrush, QColor, QStandardItemModel, QStandardItem, QIntValidator
 from skimage.transform import estimate_transform, warp
 
-from openst.utils.pseudoimage import create_pseudoimage
+from openst.utils.pseudoimage import create_paired_pseudoimage
 
 def setup_manual_pairwise_aligner_gui_parser(parent_parser):
     """setup_manual_pairwise_aligner_gui_parser"""
@@ -278,7 +278,7 @@ class ImageRenderer(QThread):
         if self.layer == "all_tiles_coarse":
             staining_image_rescaled = staining_image[:: self.rescale_factor_coarse, :: self.rescale_factor_coarse]
             
-            sts_pseudoimage = create_pseudoimage(
+            sts_pseudoimage = create_paired_pseudoimage(
                 sts_coords[:, ::-1],
                 self.pseudoimg_size,
                 staining_image_rescaled.shape,
@@ -306,7 +306,7 @@ class ImageRenderer(QThread):
                 self.layer
             )
 
-            _t_sts_pseudoimage = create_pseudoimage(
+            _t_sts_pseudoimage = create_paired_pseudoimage(
                 sts_coords[:, ::-1],  # we need to flip these coordinates
                 self.pseudoimg_size,
                 staining_image_rescaled.shape,

--- a/openst/cli.py
+++ b/openst/cli.py
@@ -17,6 +17,8 @@ from openst.segmentation.segment_merge import setup_segment_merge_parser
 from openst.threed.from_3d_registration import \
     setup_from_3d_registration_parser
 from openst.threed.to_3d_registration import setup_to_3d_registration_parser
+from openst.utils.pseudoimage import setup_pseudoimage_parser
+from openst.utils.preview import setup_preview_parser
 
 
 def cmdline_args():
@@ -53,6 +55,10 @@ def cmdline_args():
     setup_from_3d_registration_parser(parent_parser_subparsers)
     # create the parser for the "barcode_preprocessing" command
     setup_barcode_preprocessing_parser(parent_parser_subparsers)
+    # create the parser for the "pseudoimage" command
+    setup_pseudoimage_parser(parent_parser_subparsers)
+    # create the parser for the "preview" command
+    setup_preview_parser(parent_parser_subparsers)
 
     return parent_parser, parent_parser.parse_args()
 

--- a/openst/preprocessing/image_stitch.py
+++ b/openst/preprocessing/image_stitch.py
@@ -136,6 +136,7 @@ def _run_image_stitch(args):
 
     cmd = image_stitch_imagej(
         imagej_bin=args.imagej_bin,
+        microscope=args.microscope,
         input_dir=args.input_dir,
         output_image=args.output_image,
     )

--- a/openst/preprocessing/spatial_stitch.py
+++ b/openst/preprocessing/spatial_stitch.py
@@ -8,7 +8,7 @@ from anndata import AnnData, concat, read_h5ad
 from openst.utils.file import (check_directory_exists, check_file_exists,
                                check_obs_unique)
 
-DEFAULT_REGEX_tile_ID = "(L[1-4][a-b]_tile_[1-2][0-7][0-9][0-9])"
+DEFAULT_REGEX_TILE_ID = "(L[1-4][a-b]_tile_[1-2][0-7][0-9][0-9])"
 
 
 def get_spatial_stitch_parser():
@@ -53,7 +53,7 @@ def get_spatial_stitch_parser():
         "--tile-id-regex",
         type=str,
         help="regex to find tile id in file names",
-        default=DEFAULT_REGEX_tile_ID,
+        default=DEFAULT_REGEX_TILE_ID,
     )
 
     parser.add_argument(
@@ -172,14 +172,14 @@ def create_spatial_stitch(
     return tile
 
 
-def parse_tile_id_from_path(f: str, tile_id_regex: str = DEFAULT_REGEX_tile_ID):
+def parse_tile_id_from_path(f: str, tile_id_regex: str = DEFAULT_REGEX_TILE_ID):
     """
     Parse the tile ID from a file path using a regular expression.
 
     Args:
         f (str): File path.
         tile_id_regex (str, optional): Regular expression pattern for extracting the tile ID.
-                                       Defaults to DEFAULT_REGEX_tile_ID.
+                                       Defaults to DEFAULT_REGEX_TILE_ID.
 
     Returns:
         str: Extracted tile ID from the file path.
@@ -201,7 +201,7 @@ def parse_tile_id_from_path(f: str, tile_id_regex: str = DEFAULT_REGEX_tile_ID):
 def read_tiles_to_list(
     f: Union[str, List[str]],
     tile_id: Union[int, List[int], None] = None,
-    tile_id_regex: str = DEFAULT_REGEX_tile_ID,
+    tile_id_regex: str = DEFAULT_REGEX_TILE_ID,
     tile_id_key: str = "tile_id",
 ):
     """
@@ -211,7 +211,7 @@ def read_tiles_to_list(
         f (Union[str, List[str]]): File path or list of file paths to read tiles from.
         tile_id (Union[int, List[int], None], optional): Tile ID or list of tile IDs. Defaults to None.
         tile_id_regex (str, optional): Regular expression pattern for extracting tile IDs from file paths.
-                                       Defaults to DEFAULT_REGEX_tile_ID.
+                                       Defaults to DEFAULT_REGEX_TILE_ID.
         tile_id_key (str, optional): Observation key name for tile IDs in the AnnData object. Defaults to "tile_id".
 
     Returns:
@@ -269,7 +269,8 @@ def parse_tile_coordinate_system_file(f: str):
 
     cs = pd.read_csv(f, sep="[,|\t]", engine="python")
 
-    cs = cs.set_index("tile_id")
+    _tile_id_col = cs.columns[0]
+    cs = cs.set_index(_tile_id_col)
 
     cs = cs.loc[~cs.index.duplicated(keep="first")]
 

--- a/openst/segmentation/segment.py
+++ b/openst/segmentation/segment.py
@@ -39,6 +39,8 @@ def get_segment_parser():
         allow_abbrev=False,
         add_help=False,
     )
+
+    # Data
     parser.add_argument(
         "--image-in",
         type=str,
@@ -56,6 +58,8 @@ def get_segment_parser():
         type=str,
         help="When specified, staining image is loaded from adata (from --image-in), and segmentation is saved there (to --output-mask)",
     )
+    
+    # Cellpose
     parser.add_argument(
         "--model",
         type=str,
@@ -102,6 +106,8 @@ def get_segment_parser():
         action="store_true",
         help="When specified, a GPU will be used for prediction",
     )
+
+    # Postprocessing
     parser.add_argument(
         "--dilate-px",
         type=int,
@@ -116,6 +122,8 @@ def get_segment_parser():
         required=False,
         default=0,
     )
+
+    # Preprocessing
     parser.add_argument(
         "--mask-tissue",
         action="store_true",
@@ -132,6 +140,49 @@ def get_segment_parser():
         action="store_true",
         help="Whether to set the background of the imaging modalities to white after tissue masking",
     )
+
+    # RNA density-based segmentation
+    parser.add_argument(
+        "--rna-segment",
+        action="store_true",
+        help="""Performs segmentation based on local RNA density pseudoimages from sequencing data,
+              instead of using a staining image. 
+              This assumes coordinates in microns (can be transformed with --rna-segment-input-resolution)"""
+    )
+    parser.add_argument(
+        "--rna-segment-spatial-coord-key",
+        type=str,
+        default='obsm/spatial',
+        help="Path to the spatial coordinates inside the AnnData object (e.g., 'obsm/spatial')"
+    )
+    parser.add_argument(
+        "--rna-segment-input-resolution",
+        type=float,
+        default=1,
+        help="""Spatial resolution of the input coordinates (retrieved from --rna-segment-spatial-coord-key).
+              If it is in microns, leave as 1. If it is in pixels, specify the pixel to micron conversion factor."""
+    )
+    parser.add_argument(
+        "--rna-segment-render-scale",
+        type=float,
+        default=2,
+        help="Size of bins for computing the binning (in microns). For Open-ST v1, we recommend a value of 2."
+    )
+    parser.add_argument(
+        "--rna-segment-render-sigma",
+        type=float,
+        default=1,
+        help="Smoothing factor applied to the RNA pseudoimage (higher values lead to smoother images)"
+    )
+    parser.add_argument(
+        "--rna-segment-output-resolution",
+        type=float,
+        default=0.6,
+        help="Final resolution (micron/pixel) for the segmentation mask."
+    )
+    
+
+    # General
     parser.add_argument(
         "--num-workers",
         type=int,
@@ -221,7 +272,7 @@ def da_imsave(fname, arr, compute=True):
         return res
 
 
-def cellpose_segmentation(
+def run_cellpose_inference(
     im,
     model,
     diameter: float = 20,
@@ -271,11 +322,12 @@ def _segment_chunk(block, block_id, num_blocks, shift, **kwargs):
     else:
         raise ValueError(f"Expected either `2`, `3` or `4` dimensional chunks, found `{len(num_blocks)}`.")
 
-    labels = np.array(cellpose_segmentation(block, **kwargs)[0])
+    labels = np.array(run_cellpose_inference(block, **kwargs)[0])
     mask = labels > 0
     labels[mask] = (labels[mask] << shift) | block_num
 
     return labels
+
 
 def expand_labels(label_image, distance=1):
     from scipy.ndimage import distance_transform_edt
@@ -299,6 +351,50 @@ def expand_labels(label_image, distance=1):
         return expand_labels_block(label_image)
 
 
+def pseudoimage_as_input(
+    adata,
+    spatial_coord_key: str = "obsm/spatial",
+    input_resolution: float = 1,
+    render_scale: float = 1,
+    render_sigma: float = 1.5,
+    output_resolution: float = 1,
+):
+    """
+    Create pseudoimage for segmentation based on RNA density (experimental feature)
+
+    Args:
+        adata (ad.AnnData): Input AnnData object containing the spot-by-gene matrix.
+        lims (tuple): the 2D limits for cropping the spatial coordinates, as (x_min, x_max, y_min, y_max).
+        shape (tuple): the final shape of the image that will be segmented. Should lead to 1:1 aspect ratio.
+        render_scale (float): rescale the coordinates by render_scale for calculating the bin image
+        render_sigma (float): apply gaussian smoothing with render_sigma to the rendered pseudoimage.
+
+    Returns:
+        numpy.ndarray: pseudoimage.
+    """
+    from openst.utils.pseudoimage import recenter_points, show_expression_on_image
+    _spatial_coords = adata[spatial_coord_key]
+    _total_counts = adata["obs/total_counts"]
+
+    marker_filtered = recenter_points(_spatial_coords)
+    marker_filtered = marker_filtered[np.repeat(np.arange(len(marker_filtered)), _total_counts)]
+    marker_filtered_scaled = marker_filtered * input_resolution
+
+    pim = show_expression_on_image(marker_filtered_scaled, render_scale, render_sigma, output_resolution)
+
+    # we need to write the transformed coordinates so they can be applied to the pseudo image
+    _out_spatial_coord_key = f"{spatial_coord_key}_pseudoimage_scale_{render_scale}_sigma_{render_sigma}"
+    if _out_spatial_coord_key in adata:
+        adata[_out_spatial_coord_key][...] = marker_filtered_scaled[:] * output_resolution
+    else:
+        adata[_out_spatial_coord_key] = marker_filtered_scaled[:] * output_resolution
+
+    logging.info(f"Added transformed coordinates as {_out_spatial_coord_key} to the AnnData")
+
+    return pim
+
+
+
 def _run_segment(args):
     """
     Wrapper for whole or tiled segmentation with cellpose.
@@ -317,31 +413,12 @@ def _run_segment(args):
     except ImportError:
         raise ImportError("'cellpose' could not be found. Please install with 'pip install cellpose'")
 
-    # Check input and output data
-    im = None
-    if args.adata != '':
-        check_file_exists(args.adata)
-        adata = h5py.File(args.adata, 'r+')
-        im = adata[args.image_in]
-        if args.chunked:
-            im = da.from_array(im)
-        else:
-            im = im[:]
-
-    else:
-        check_file_exists(args.image_in)
-        if not check_directory_exists(args.output_mask):
-            raise FileNotFoundError("Parent directory for --output-mask does not exist")
-
     if args.metadata_out != "" and not check_directory_exists(args.metadata_out):
         raise FileNotFoundError("Parent directory for the metadata does not exist")
     
     _num_workers = 1
     if args.num_workers > 0:
         _num_workers = args.num_workers
-
-    # Set maximum image size to support large HE (if not chunked)
-    Image.MAX_IMAGE_PIXELS = args.max_image_pixels
 
     # Load cellpose model (path or pretrained)
     if args.model in models.MODEL_NAMES:
@@ -350,16 +427,11 @@ def _run_segment(args):
         check_file_exists(args.model)
         model = models.CellposeModel(gpu=args.gpu, pretrained_model=args.model)
 
-
     if args.chunked:
         logging.info("Loading images into chunks")
         # TODO: implement checking of input file (dimensions)
-        if im is None:
-            im = dask_image.imread.imread(args.image_in)[0] # to have 3 dimensions
-
         im = im.rechunk({0: args.chunk_size, 1: args.chunk_size})
         shift = int(np.prod(im.numblocks) - 1).bit_length()
-
         
         # This dask chunked option is useful for limited GPU memory
         # we need to specify processes scheduler such that CUDA
@@ -396,33 +468,7 @@ def _run_segment(args):
                 if args.outline_px > 0:
                     mask_complete = find_boundaries(mask_complete, connectivity=1, mode='inner', background=0)
                     mask_complete = da.where(mask_complete, mask_complete, 0)
-
-                # Transpose the image, so the axes are cxy
-                if args.adata:
-                    if args.output_mask in adata:
-                        logging.warn(f"The object {args.output_mask} will be removed from the h5py file")
-                        del adata[args.output_mask]
-
-                    dset = adata.create_dataset(args.output_mask, shape=mask_complete.shape,
-                                                    dtype=mask_complete.dtype)  
-                    logging.info(f'Saving mask to adata in {args.output_mask}')
-                    da.store(mask_complete, dset)
-
-                    logging.info(f'Relabeling mask in {args.output_mask}')
-                    adata[args.output_mask][...] = measure.label(adata[args.output_mask])
-                    
-                else:
-                    # Save large image mask as zarr
-                    store = parse_url(args.output_mask, mode="w").store
-                    root = zarr.group(store=store)
-                    labels_grp = root.create_group('labels')
-                    logging.info(f'Saving mask to separate file in {args.output_mask}')
-                    write_image(im.transpose(2, 0, 1), group=root, compute=True, axes=['c', 'x', 'y'])
-                    write_image(mask_complete, group=labels_grp, compute=True, axes=['x', 'y'])
     else:
-        if im is None:
-            im = np.array(Image.open(args.image_in))
-
         if args.mask_tissue:
             logging.info("Masking whole tissue from background")
             im = mask_tissue(im, 
@@ -431,21 +477,13 @@ def _run_segment(args):
                             return_hsv=False)
 
         logging.info("Segmenting & relabeling whole image")
-        mask_complete = cellpose_segmentation(
+        mask_complete = run_cellpose_inference(
             im,
             model,
             diameter=args.diameter,
             flow_threshold=args.flow_threshold,
             cellprob_threshold=args.cellprob_threshold,
         )[0]
-
-        dtype = np.uint8
-        if mask_complete.max() >= (2**16 - 1):
-            dtype = np.uint16
-        elif mask_complete.max() >= (2**32 - 1):
-            dtype = np.uint32
-        elif mask_complete.max() >= (2**64 - 1):
-            dtype = np.uint64
 
         if args.dilate_px > 0:
             mask_complete = expand_labels(mask_complete, distance=args.dilate_px)
@@ -456,6 +494,72 @@ def _run_segment(args):
             mask_complete = np.where(mask_complete_bdy, mask_complete, 0)
 
         mask_complete = measure.label(mask_complete)
+
+    return im, mask_complete
+
+def _load_image(args):
+    if args.adata != '':
+        check_file_exists(args.adata)
+        adata = h5py.File(args.adata, 'r+')
+
+        if args.rna_segment:
+            im = pseudoimage_as_input(adata, 
+                                      args.rna_segment_render_spatial_coord_key,
+                                      args.rna_segment_render_input_resolution,
+                                      args.rna_segment_render_scale,
+                                      args.rna_segment_render_sigma,
+                                      args.rna_segment_render_output_resolution)
+            logging.info("Will perform segmentation on a")
+        else:
+            im = adata[args.image_in]
+            if args.chunked:
+                im = da.from_array(im)
+            else:
+                im = im[:]
+
+    else:
+        check_file_exists(args.image_in)
+        if not check_directory_exists(args.output_mask):
+            raise FileNotFoundError("Parent directory for --output-mask does not exist")
+        if args.chunked:
+            im = dask_image.imread.imread(args.image_in)[0] # to have 3 dimensions
+        else:
+            im = np.array(Image.open(args.image_in))
+        
+    return im
+
+def _save_mask(adata, im, mask_complete, args):
+    # Transpose the image, so the axes are cxy
+    if args.chunked:
+        if args.adata:
+            if args.output_mask in adata:
+                logging.warn(f"The object {args.output_mask} will be removed from the h5py file")
+                del adata[args.output_mask]
+
+            dset = adata.create_dataset(args.output_mask, shape=mask_complete.shape,
+                                            dtype=mask_complete.dtype)  
+            logging.info(f'Saving mask to adata in {args.output_mask}')
+            da.store(mask_complete, dset)
+
+            logging.info(f'Relabeling mask in {args.output_mask}')
+            adata[args.output_mask][...] = measure.label(adata[args.output_mask])
+            
+        else:
+            # Save large image mask as zarr
+            store = parse_url(args.output_mask, mode="w").store
+            root = zarr.group(store=store)
+            labels_grp = root.create_group('labels')
+            logging.info(f'Saving mask to separate file in {args.output_mask}')
+            write_image(im.transpose(2, 0, 1), group=root, compute=True, axes=['c', 'x', 'y'])
+            write_image(mask_complete, group=labels_grp, compute=True, axes=['x', 'y'])
+    else:
+        dtype = np.uint8
+        if mask_complete.max() >= (2**16 - 1):
+            dtype = np.uint16
+        elif mask_complete.max() >= (2**32 - 1):
+            dtype = np.uint32
+        elif mask_complete.max() >= (2**64 - 1):
+            dtype = np.uint64
 
         if args.adata:
             if args.output_mask in adata:
@@ -468,7 +572,12 @@ def _run_segment(args):
             logging.info(f'Saving mask to separate file in {args.output_mask}')
             Image.fromarray(mask_complete.astype(dtype)).save(args.output_mask)
 
-
 if __name__ == "__main__":
     args = get_segment_parser().parse_args()
-    _run_segment(args)
+    
+    # Set maximum image size to support large HE (if not chunked)
+    Image.MAX_IMAGE_PIXELS = args.max_image_pixels
+
+    adata, im = _load_image(args)
+    im, mask_complete = _run_segment(adata, im, args)
+    _save_mask(adata, im, mask_complete, args)

--- a/openst/utils/file.py
+++ b/openst/utils/file.py
@@ -188,3 +188,21 @@ def copytree2(source: str, dest: str) -> str:
     else:
         shutil.copytree(source, dest_dir, dirs_exist_ok=True)
     return dest_dir
+
+def get_package_path():
+    """Get the absolute path of the directory containing the current Python package."""
+    import openst
+    return os.path.dirname(os.path.abspath(openst.__file__))
+
+def get_absolute_package_path(relative_path):
+    """
+    Get the absolute path by concatenating the package path and the relative path.
+
+    Parameters:
+        relative_path (str): Relative path from the package directory.
+
+    Returns:
+        str: Absolute path.
+    """
+    package_path = get_package_path()
+    return os.path.join(package_path, relative_path)

--- a/openst/utils/pimage.py
+++ b/openst/utils/pimage.py
@@ -260,3 +260,22 @@ def mask_tissue(
         return image_out, hsv_image_out
     else:
         return image_out
+    
+
+
+def is_grayscale(image):
+    """
+    Check if an image is grayscale (2D).
+
+    Parameters:
+        image (numpy.ndarray): Input image.
+
+    Returns:
+        bool: True if the image is grayscale (2D), False otherwise.
+    """
+    if isinstance(image, np.ndarray):
+        if len(image.shape) == 2:
+            return True
+        elif len(image.shape) == 3 and image.shape[2] == 1:
+            return True
+    return False

--- a/openst/utils/preview.py
+++ b/openst/utils/preview.py
@@ -1,0 +1,118 @@
+import argparse
+import cv2
+import numpy as np
+from skimage.transform import resize
+from skimage.filters import gaussian
+import logging
+
+def get_preview_parser():
+    """
+    Parse command-line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="preview pseudoimage and images of Open-ST data",
+        allow_abbrev=False,
+        add_help=False,
+    )
+    # Input
+    parser.add_argument(
+        "--adata",
+        type=str,
+        required=True,
+        help="Necessary to create the pseudoimage",
+    )
+
+    # RNA density-based pseudoimage
+    parser.add_argument(
+        "--spatial-coord-keys",
+        type=str,
+        nargs="+",
+        default=None,
+        help="""Path to the spatial coordinates inside the AnnData object (e.g., 'obsm/spatial').
+                Can be one or many (separated by space)"""
+    )
+
+    # Staining image
+    parser.add_argument(
+        "--image-keys",
+        type=str,
+        nargs="+",
+        default=None,
+        help="""Path to the image to be visualized.
+              Can be one or many (separated by space)"""
+    )
+
+    # Resampling before previsualizing
+    parser.add_argument(
+        "--spatial-coord-resampling",
+        type=int,
+        nargs="+",
+        default=1,
+        help="""Will load every n-th point. Can be one (same for all spatial-coords)
+                or many (1-to-1 mapping to the spatial-coord list)"""
+    )
+    parser.add_argument(
+        "--image-resampling",
+        type=int,
+        nargs="+",
+        default=1,
+        help="""Will load every n-th pixel. Can be one (same for all images)
+                or many (1-to-1 mapping to the image list)"""
+    )
+
+    return parser
+
+def setup_preview_parser(parent_parser):
+    """setup_preview_parser"""
+    parser = parent_parser.add_parser(
+        "preview",
+        help="prepreview the dataset with napari",
+        parents=[get_preview_parser()],
+    )
+    parser.set_defaults(func=_run_preview)
+
+    return parser
+
+def _run_preview(args):
+    import h5py
+    try:
+        import napari
+    except ImportError:
+        raise ImportError(
+            "Please install napari: `pip install napari`."
+        )
+
+    from openst.utils.file import check_file_exists
+    
+    check_file_exists(args.adata)
+    adata = h5py.File(args.adata, 'r+')
+
+    viewer = napari.Viewer()
+
+    if args.image_keys is not None:
+        for i, _image_key in enumerate(args.image_keys):
+            if len(args.image_resampling) != len(args.image_keys):
+                image_resampling = args.image_resampling[0]
+            else:
+                image_resampling = args.image_resampling[i]
+
+            print(adata[_image_key].shape)
+            viewer.add_image(data=adata[_image_key][::image_resampling, ::image_resampling])
+
+    if args.spatial_coord_keys is not None:
+        for i, _spatial_coord_key in enumerate(args.spatial_coord_keys):
+            if len(args.spatial_coord_resampling) != len(args.spatial_coord_keys):
+                spatial_coord_resampling = args.spatial_coord_resampling[0]
+            else:
+                spatial_coord_resampling = args.spatial_coord_resampling[i]
+
+            viewer.add_points(data=adata[_spatial_coord_key][::spatial_coord_resampling])
+    
+    napari.run()
+
+if __name__ == "__main__":
+    args = get_preview_parser().parse_args()
+    _run_preview()

--- a/openst/utils/preview.py
+++ b/openst/utils/preview.py
@@ -50,7 +50,7 @@ def get_preview_parser():
         "--spatial-coord-resampling",
         type=int,
         nargs="+",
-        default=1,
+        default=[1],
         help="""Will load every n-th point. Can be one (same for all spatial-coords)
                 or many (1-to-1 mapping to the spatial-coord list)"""
     )
@@ -58,7 +58,7 @@ def get_preview_parser():
         "--image-resampling",
         type=int,
         nargs="+",
-        default=1,
+        default=[1],
         help="""Will load every n-th pixel. Can be one (same for all images)
                 or many (1-to-1 mapping to the image list)"""
     )

--- a/openst/utils/preview.py
+++ b/openst/utils/preview.py
@@ -99,7 +99,6 @@ def _run_preview(args):
             else:
                 image_resampling = args.image_resampling[i]
 
-            print(adata[_image_key].shape)
             viewer.add_image(data=adata[_image_key][::image_resampling, ::image_resampling])
 
     if args.spatial_coord_keys is not None:

--- a/openst/utils/pseudoimage.py
+++ b/openst/utils/pseudoimage.py
@@ -1,6 +1,7 @@
 import cv2
 import numpy as np
 from skimage.transform import resize
+from skimage.filters import gaussian
 
 
 def create_pseudoimage(
@@ -120,3 +121,23 @@ def create_pseudoimage(
     }
 
     return pseudoimage_and_metadata
+
+
+# pseudoimage for density segmentation
+def recenter_points(points):
+    points_roi = points.copy()
+    points_roi[:, 0] = points_roi[:, 0] - points[:, 0].min()
+    points_roi[:, 1] = points_roi[:, 1] - points[:, 1].min()
+    return points_roi
+
+def show_expression_on_image(points_roi,
+                             render_scale: int = 1, 
+                             render_sigma: float = 1.5,
+                             output_resolution: float = 1):
+    im_shape = points_roi.max(axis=0)
+
+    gene_im, _, _ = np.histogram2d(points_roi[:, 0], points_roi[:, 1],
+                                   bins=tuple((im_shape * render_scale).astype(int)))
+    gene_im = gaussian(gene_im, render_sigma)
+    gene_im = resize(gene_im, tuple((im_shape * output_resolution).astype(int)))
+    return gene_im

--- a/openst/utils/pseudoimage.py
+++ b/openst/utils/pseudoimage.py
@@ -257,7 +257,12 @@ def create_unpaired_pseudoimage(
 
 def _run_pseudoimage_visualizer(args):
     import h5py
-    import napari
+    try:
+        import napari
+    except ImportError:
+        raise ImportError(
+            "Please install napari: `pip install napari`."
+        )
 
     from openst.utils.file import check_file_exists
     

--- a/openst/utils/pseudoimage.py
+++ b/openst/utils/pseudoimage.py
@@ -1,10 +1,76 @@
+import argparse
 import cv2
 import numpy as np
 from skimage.transform import resize
 from skimage.filters import gaussian
+import logging
 
+def get_pseudoimage_parser():
+    """
+    Parse command-line arguments.
 
-def create_pseudoimage(
+    Returns:
+        argparse.Namespace: Parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="generate and visualize pseudoimage of Open-ST RNA data",
+        allow_abbrev=False,
+        add_help=False,
+    )
+    # Input
+    parser.add_argument(
+        "--adata",
+        type=str,
+        required=True,
+        help="Necessary to create the pseudoimage",
+    )
+
+    # RNA density-based pseudoimage
+    parser.add_argument(
+        "--spatial-coord-key",
+        type=str,
+        default='obsm/spatial',
+        help="Path to the spatial coordinates inside the AnnData object (e.g., 'obsm/spatial')"
+    )
+    parser.add_argument(
+        "--input-resolution",
+        type=float,
+        default=1,
+        help="""Spatial resolution of the input coordinates (retrieved from --spatial-coord-key).
+              If it is in microns, leave as 1. If it is in pixels, specify the pixel to micron conversion factor."""
+    )
+    parser.add_argument(
+        "--render-scale",
+        type=float,
+        default=2,
+        help="Size of bins for computing the binning (in microns). For Open-ST v1, we recommend a value of 2."
+    )
+    parser.add_argument(
+        "--render-sigma",
+        type=float,
+        default=1,
+        help="Smoothing factor applied to the RNA pseudoimage (higher values lead to smoother images)"
+    )
+    parser.add_argument(
+        "--output-resolution",
+        type=float,
+        default=0.6,
+        help="Final resolution (micron/pixel) for the segmentation mask."
+    )
+    return parser
+
+def setup_pseudoimage_parser(parent_parser):
+    """setup_pseudoimage_parser"""
+    parser = parent_parser.add_parser(
+        "pseudoimage",
+        help="generate and visualize pseudoimage of Open-ST RNA data",
+        parents=[get_pseudoimage_parser()],
+    )
+    parser.set_defaults(func=_run_pseudoimage_visualizer)
+
+    return parser
+
+def create_paired_pseudoimage(
     coords: np.ndarray,
     scale: float,
     target_size: tuple = None,
@@ -15,7 +81,8 @@ def create_pseudoimage(
     resize_method: str = 'scikit-image',
 ) -> dict:
     """
-    Create a pseudoimage representation from input coordinates (two-dimensional).
+    Create a pseudoimage representation from input coordinates (two-dimensional), paired
+    to a staining image (will set the limits and dimensions accordingly)
 
     Args:
         coords (np.ndarray): Input coordinates to create the pseudoimage from.
@@ -137,7 +204,77 @@ def show_expression_on_image(points_roi,
     im_shape = points_roi.max(axis=0)
 
     gene_im, _, _ = np.histogram2d(points_roi[:, 0], points_roi[:, 1],
-                                   bins=tuple((im_shape * render_scale).astype(int)))
+                                   bins=tuple((im_shape * (1/render_scale)).astype(int)))
     gene_im = gaussian(gene_im, render_sigma)
     gene_im = resize(gene_im, tuple((im_shape * output_resolution).astype(int)))
     return gene_im
+
+def create_unpaired_pseudoimage(
+    adata,
+    spatial_coord_key: str = "obsm/spatial",
+    input_resolution: float = 1,
+    render_scale: float = 1,
+    render_sigma: float = 1.5,
+    output_resolution: float = 1,
+):
+    """
+    Create pseudoimage for segmentation based on RNA density (experimental feature), i.e.,
+    not paired to a staining image (no cropping, no rescaling)
+
+    Args:
+        adata (ad.AnnData): Input AnnData object containing the spot-by-gene matrix.
+        lims (tuple): the 2D limits for cropping the spatial coordinates, as (x_min, x_max, y_min, y_max).
+        shape (tuple): the final shape of the image that will be segmented. Should lead to 1:1 aspect ratio.
+        render_scale (float): rescale the coordinates by render_scale for calculating the bin image
+        render_sigma (float): apply gaussian smoothing with render_sigma to the rendered pseudoimage.
+
+    Returns:
+        numpy.ndarray: pseudoimage
+        numpy.ndarray: transformed points
+    """
+
+    _spatial_coords = adata[spatial_coord_key][:]
+    _total_counts = adata["obs/total_counts"][:].astype(int)
+
+    marker_filtered = recenter_points(_spatial_coords)
+    marker_filtered = marker_filtered[np.repeat(np.arange(len(marker_filtered)), _total_counts)]
+    marker_filtered_scaled = marker_filtered * input_resolution
+
+    pim = show_expression_on_image(marker_filtered_scaled, render_scale, render_sigma, output_resolution)
+    logging.info(f"Created pseudoimage with {pim.shape} pixels")
+
+    # we need to write the transformed coordinates so they can be applied to the pseudo image
+    _out_spatial_coord_key = f"{spatial_coord_key}_pseudoimage_scale_{render_scale}_sigma_{render_sigma}"
+    marker_filtered_scaled = marker_filtered_scaled * output_resolution
+    if _out_spatial_coord_key in adata:
+        adata[_out_spatial_coord_key][...] = marker_filtered_scaled
+    else:
+        adata[_out_spatial_coord_key] = marker_filtered_scaled
+
+    logging.info(f"Added transformed coordinates as {_out_spatial_coord_key} to the AnnData")
+
+    return pim, marker_filtered_scaled
+
+def _run_pseudoimage_visualizer(args):
+    import h5py
+    import napari
+
+    from openst.utils.file import check_file_exists
+    
+    check_file_exists(args.adata)
+    adata = h5py.File(args.adata, 'r+')
+    
+    im, pts = create_unpaired_pseudoimage(adata, 
+                                     args.spatial_coord_key,
+                                     args.input_resolution,
+                                     args.render_scale,
+                                     args.render_sigma,
+                                     args.output_resolution)
+    
+    viewer = napari.Viewer()
+    viewer.add_image(data=im)
+    napari.run()
+
+if __name__ == "__main__":
+    args = get_pseudoimage_parser().parse_args()
+    _run_pseudoimage_visualizer()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "openst"
-version = "0.0.3"
+version = "0.0.5"
 description = "The computational pipeline for the Open-ST method."
 license = "GPL-2.0"
 authors = [


### PR DESCRIPTION
Add an alternative mode for segmenting the Open-ST data based on the RNA density (very simple, computes local density of total counts with a specific resolution and smoothing radius, and then applies cellpose, preferably the nuclei model).

Also, adds a preview and pseudoimage functionality that leverages napari for visualization.