### PR TITLE
Fixed isadirectory error in flowcell_map.py

### DIFF
--- a/openst/preprocessing/flowcell_map.py
+++ b/openst/preprocessing/flowcell_map.py
@@ -480,7 +480,10 @@ def _run_flowcell_map(args: argparse.Namespace):
     logging.info("Cleaning temporary directories and files")
     for d in [args.bcl_out, args.tilecoords_out, args.dedup_out, args.merge_out, args.distribute_out]:
         if os.path.exists(d):
-            os.remove(d)
+            if os.path.isdir(d):
+                shutil.rmtree(d)
+            elif os.path.isfile(d):
+                os.remove(d)
 
     # TODO: create a file with statistics (how many tiles are created, how many barcodes, how many deduplicated)
     logging.info("Flowcell mapping completed successfully")


### PR DESCRIPTION
#FIX:
```python
if os.path.isdir(d):
    shutil.rmtree(d)
elif os.path.isfile(d):
    os.remove(d)
```

Output:
```
Merging files: 100%|██████████| 284/284 [00:49<00:00,  5.69it/s]
INFO 2025-02-03 10:13:57,697 - File distribution completed. Output in /var/data/out
INFO 2025-02-03 10:13:57,698 - Cleaning temporary directories and files
Traceback (most recent call last):
  File "/usr/local/bin/openst", line 8, in <module>
    sys.exit(run_openst())
             ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/openst/__main__.py", line 11, in run_openst
    cmdline_main()
  File "/usr/local/lib/python3.11/site-packages/openst/cli.py", line 1583, in cmdline_main
    args.func(args)
  File "/usr/local/lib/python3.11/site-packages/openst/cli.py", line 846, in cmd_run_flowcell_map
    _run_flowcell_map(args)
  File "/usr/local/lib/python3.11/site-packages/openst/preprocessing/flowcell_map.py", line 483, in _run_flowcell_map
    os.remove(d)
IsADirectoryError: [Errno 21] Is a directory: '/var/data/out/bcl_out'
```

## Steps to reproduce the bug
```sh
openst flowcell_map --bcl-in /var/data/in --tiles-out /var/data/out --crop-seq 5:30  --parallel-processes 48  --rev-comp
```


## Environment info
- Platform: Docker/singularity container
- Python version: 3.11.11