### PR TITLE
Update manual_pairwise_aligner.py

### DIFF
--- a/openst/alignment/manual_pairwise_aligner.py
+++ b/openst/alignment/manual_pairwise_aligner.py
@@ -658,7 +658,7 @@ class ImageAlignmentApp(QMainWindow):
         self.point_size_slider_label = QLabel("Point size", self)
         self.point_size_slider = QSlider(Qt.Horizontal)
         self.point_size_slider.setMinimum(1)
-        self.point_size_slider.setMaximum(200)
+        self.point_size_slider.setMaximum(300)
         self.point_size_slider.setValue(100)
         lay.addWidget(self.point_size_slider_label)
         lay.addWidget(self.point_size_slider)


### PR DESCRIPTION
Increase the maximum value of the points from self.point_size_slider.setMaximum(200) to 300. 

This allows users to annotate points to the fill size of the fiducials.
In some cases when it is hard to view the fiducials due to them being hidden by the tissue. 
I have had an easier time pinpointing fiducials with a larger circle. Moreover, the paired-wise alignment also benefits from larger circles, as a slight miss alignment of a large circle has less impact as of a small circle being out of place. 

Best Christian